### PR TITLE
Fix shopping item expiration date

### DIFF
--- a/refrigerator_management/Models/ShoppingItem.swift
+++ b/refrigerator_management/Models/ShoppingItem.swift
@@ -5,6 +5,12 @@ struct ShoppingItem: Identifiable, Codable, Equatable {
     let id: UUID
     var name: String
     var quantity: Int = 1
+    /// The expected expiration date when the item is converted to a `FoodItem`.
+    ///
+    /// This value is optional because shopping items created manually do not
+    /// always have an expiration date. `ShoppingListView` falls back to a
+    /// default date if this value is `nil` when adding to stock.
+    var expirationDate: Date?
     var manuallyAdded: Bool
     var linkedFoodItemID: UUID?
     var note: String?
@@ -16,6 +22,7 @@ struct ShoppingItem: Identifiable, Codable, Equatable {
         id: UUID = UUID(),
         name: String,
         quantity: Int = 1,
+        expirationDate: Date? = nil,
         manuallyAdded: Bool = true,
         linkedFoodItemID: UUID? = nil,
         note: String? = nil,
@@ -25,6 +32,7 @@ struct ShoppingItem: Identifiable, Codable, Equatable {
         self.id = id
         self.name = name
         self.quantity = quantity
+        self.expirationDate = expirationDate
         self.manuallyAdded = manuallyAdded
         self.linkedFoodItemID = linkedFoodItemID
         self.note = note

--- a/refrigerator_management/ViewModels/ShoppingViewModel.swift
+++ b/refrigerator_management/ViewModels/ShoppingViewModel.swift
@@ -68,6 +68,7 @@ class ShoppingViewModel: ObservableObject {
         if let index = shoppingItems.firstIndex(where: { $0.name == foodItem.name }) {
             shoppingItems[index].name = foodItem.name
             shoppingItems[index].quantity = foodItem.quantity
+            shoppingItems[index].expirationDate = foodItem.expirationDate
             save()
         }
     }

--- a/refrigerator_management/Views/ShoppingListView.swift
+++ b/refrigerator_management/Views/ShoppingListView.swift
@@ -69,7 +69,11 @@ struct ShoppingListView: View {
                     id: item.id,
                     name: item.name,
                     quantity: item.quantity,
-                    expirationDate: item.expirationDate,
+                    // Use the item's expiration date if available, otherwise
+                    // provide a temporary value so the editor has something to
+                    // display. The value can be adjusted by the user before
+                    // saving.
+                    expirationDate: item.expirationDate ?? Date(),
                     storageType: selectedStorageType
                 )
                 FoodRegisterView(itemToEdit: foodItem) { updatedItem in


### PR DESCRIPTION
## Summary
- add optional expiration date to ShoppingItem model
- propagate expiration date when editing items
- save expiration date when updating from FoodItem

## Testing
- `swiftc refrigerator_management/Views/ShoppingListView.swift` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_6862a11ffa80832fa33a4c1f28596073