### PR TITLE
Unify add button behavior

### DIFF
--- a/refrigerator_management/Views/ShoppingListView.swift
+++ b/refrigerator_management/Views/ShoppingListView.swift
@@ -5,6 +5,7 @@ struct ShoppingListView: View {
     @ObservedObject var foodViewModel: FoodViewModel
     @ObservedObject var templateViewModel: TemplateViewModel
     @State private var editingItem: ShoppingItem? = nil
+    @State private var showingRegister = false
     @State private var showingTemplateNameAlert = false
     @State private var newTemplateName: String = ""
 
@@ -62,7 +63,7 @@ struct ShoppingListView: View {
             .navigationTitle("買い物リスト")
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    Button(action: addNewItem) {
+                    Button(action: { showingRegister = true }) {
                         Image(systemName: "plus")
                     }
                 }
@@ -103,6 +104,18 @@ struct ShoppingListView: View {
             }
         }
         .navigationViewStyle(.stack)
+        .sheet(isPresented: $showingRegister) {
+            FoodRegisterView { newItem in
+                let shoppingItem = ShoppingItem(
+                    name: newItem.name,
+                    quantity: newItem.quantity,
+                    expirationDate: newItem.expirationDate,
+                    storageType: newItem.storageType,
+                    category: newItem.category
+                )
+                shoppingViewModel.add(shoppingItem)
+            }
+        }
         .alert("テンプレート名を入力", isPresented: $showingTemplateNameAlert) {
             TextField("テンプレート名", text: $newTemplateName)
             Button("保存") {
@@ -110,11 +123,6 @@ struct ShoppingListView: View {
             }
             Button("キャンセル", role: .cancel) {}
         }
-    }
-
-    private func addNewItem() {
-        let newItem = ShoppingItem(name: "")
-        shoppingViewModel.add(newItem)
     }
 
     // ✅ ShoppingItem の storageType / expirationDate を反映して在庫に変換


### PR DESCRIPTION
## Summary
- use the same add-item workflow in `ShoppingListView`
- open `FoodRegisterView` when tapping the + button and add the created item to the shopping list

## Testing
- `xcodebuild` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a1d311658832faaa42c4e2c10cfb2