### PR TITLE
Fix SwiftUI preview for older toolchains

### DIFF
--- a/refrigerator_management/ContentView.swift
+++ b/refrigerator_management/ContentView.swift
@@ -42,6 +42,10 @@ struct ContentView: View {
     }
 }
 
-#Preview {
-    ContentView()
+#if DEBUG
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
 }
+#endif


### PR DESCRIPTION
## Summary
- replace the new `#Preview` macro with a traditional `PreviewProvider` so builds on older Swift versions succeed

## Testing
- `swiftc /tmp/test.swift 2>&1 | head` *(fails: no SwiftUI module available)*

------
https://chatgpt.com/codex/tasks/task_e_686a37e2de7c832f9490329a85d95626