### PR TITLE
Improve shopping list and template editing

### DIFF
--- a/refrigerator_management/Views/ShoppingListView.swift
+++ b/refrigerator_management/Views/ShoppingListView.swift
@@ -78,20 +78,6 @@ struct ShoppingListView: View {
                 }
                 .environment(\.editMode, $editMode)
 
-                Button(action: {
-                    processCheckedItems()
-                }) {
-                    Text("チェック済みを在庫に反映")
-                        .font(.headline)
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(Color.blue)
-                        .foregroundColor(.white)
-                        .cornerRadius(12)
-                        .padding(.horizontal)
-                }
-                .padding(.bottom)
-                Spacer()
             }
             .overlay(
                 VStack {
@@ -107,6 +93,15 @@ struct ShoppingListView: View {
                                 .padding()
                         }
                         Spacer()
+                        Button(action: {
+                            processCheckedItems()
+                        }) {
+                            Image(systemName: "cart.fill.badge.plus")
+                                .resizable()
+                                .frame(width: 60, height: 60)
+                                .foregroundColor(.blue)
+                                .padding()
+                        }
                     }
                 }
             )

--- a/refrigerator_management/Views/TemplateEditView.swift
+++ b/refrigerator_management/Views/TemplateEditView.swift
@@ -11,34 +11,48 @@ struct TemplateEditView: View {
             }
 
             Section(header: Text("食材一覧")) {
-                ForEach($template.items) { $item in
+                ForEach(template.items.indices, id: \.self) { index in
                     VStack(alignment: .leading) {
-                        TextField("食材名", text: $item.name)
-                        Stepper(value: $item.quantity, in: 1...99) {
-                            Text("数量: \(item.quantity)")
+                        TextField("食材名", text: $template.items[index].name)
+                        Stepper(value: $template.items[index].quantity, in: 1...99) {
+                            Text("数量: \(template.items[index].quantity)")
                         }
                         DatePicker(
                             "賞味期限",
                             selection: Binding(
-                                get: { item.expirationDate ?? Date() },
-                                set: { item.expirationDate = $0 }
+                                get: { template.items[index].expirationDate ?? Date() },
+                                set: { template.items[index].expirationDate = $0 }
                             ),
                             displayedComponents: .date
                         )
-                        Picker("保存場所", selection: $item.storageType) {
+                        Picker("保存場所", selection: $template.items[index].storageType) {
                             ForEach(StorageType.allCases) { type in
                                 Text(type.rawValue).tag(type)
                             }
                         }
-                        Picker("カテゴリ", selection: $item.category) {
+                        Picker("カテゴリ", selection: $template.items[index].category) {
                             ForEach(FoodCategory.allCases) { cat in
                                 Text(cat.rawValue).tag(cat)
                             }
                         }
+                        HStack {
+                            Spacer()
+                            Button(role: .destructive) {
+                                template.items.remove(at: index)
+                            } label: {
+                                Image(systemName: "trash")
+                                    .foregroundColor(.red)
+                            }
+                        }
                     }
                 }
-                .onDelete { offsets in
-                    template.items.remove(atOffsets: offsets)
+                Button(action: {
+                    template.items.append(TemplateItem(name: ""))
+                }) {
+                    HStack {
+                        Image(systemName: "plus.circle.fill")
+                        Text("食材を追加")
+                    }
                 }
             }
         }

--- a/refrigerator_management/Views/TemplateListView.swift
+++ b/refrigerator_management/Views/TemplateListView.swift
@@ -51,7 +51,7 @@ struct TemplateListView: View {
             }
             .navigationTitle("テンプレート選択")
         }
-        .alert("このテンプレートを反映しますか？", isPresented: $showingConfirm, presenting: templateToApply) { template in
+        .alert("このテンプレートを買い物リストに反映しますか？", isPresented: $showingConfirm, presenting: templateToApply) { template in
             Button("キャンセル", role: .cancel) {}
             Button("追加") {
                 addTemplateToShoppingList(template)


### PR DESCRIPTION
## Summary
- adjust popup wording when applying templates to shopping list
- allow adding/removing ingredients while editing a template
- move "checked to inventory" action to floating button to avoid overlapping the edit button

## Testing
- `swift test -l` *(fails: no Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686a6bcb6384832fae2204597e3565cc