### PR TITLE
Fix edit mode persistence and align FoodListView title

### DIFF
--- a/refrigerator_management/Views/FoodListView.swift
+++ b/refrigerator_management/Views/FoodListView.swift
@@ -27,11 +27,6 @@ struct FoodListView: View {
     var body: some View {
         ZStack {
             VStack {
-                Text("食材一覧")
-                    .font(.largeTitle)
-                    .bold()
-                    .padding(.top)
-
                 Picker("保存場所", selection: $selectedStorage) {
                     ForEach(StorageType.allCases) { type in
                         Text(type.rawValue).tag(type)
@@ -130,6 +125,11 @@ struct FoodListView: View {
                 performDelete()
             }
         }
+        .onDisappear {
+            editMode = .inactive
+            selection.removeAll()
+        }
+        .navigationTitle("食材一覧")
     }
 
     func deleteItem(at offsets: IndexSet) {

--- a/refrigerator_management/Views/ShoppingListView.swift
+++ b/refrigerator_management/Views/ShoppingListView.swift
@@ -190,6 +190,10 @@ struct ShoppingListView: View {
                 processCheckedItems()
             }
         }
+        .onDisappear {
+            editMode = .inactive
+            selection.removeAll()
+        }
     }
     }
 


### PR DESCRIPTION
## Summary
- remove heading text in FoodListView and use navigation bar title
- reset edit mode when leaving FoodListView/ShoppingListView so toolbar buttons disappear

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686a76390d38832fa65ecaef914faa22