### PR TITLE
Fix food list title missing

### DIFF
--- a/refrigerator_management/Views/FoodListView.swift
+++ b/refrigerator_management/Views/FoodListView.swift
@@ -25,8 +25,9 @@ struct FoodListView: View {
     }
 
     var body: some View {
-        ZStack {
-            VStack {
+        NavigationView {
+            ZStack {
+                VStack {
                 Picker("保存場所", selection: $selectedStorage) {
                     ForEach(StorageType.allCases) { type in
                         Text(type.rawValue).tag(type)
@@ -131,6 +132,7 @@ struct FoodListView: View {
         }
         .navigationTitle("食材一覧")
     }
+}
 
     func deleteItem(at offsets: IndexSet) {
         deleteOffsets = offsets


### PR DESCRIPTION
## Summary
- wrap FoodListView in `NavigationView` so the title shows and lines up with other screens

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a79204668832fb8099ede482544b1