### PR TITLE
Fix FoodListView swipe actions and update deprecated onChange

### DIFF
--- a/refrigerator_management/Views/FoodListView.swift
+++ b/refrigerator_management/Views/FoodListView.swift
@@ -53,15 +53,15 @@ struct FoodListView: View {
                                 editingItem = item
                             }
                         }
-                    }
-                    .swipeActions {
-                        Button(role: .destructive) {
-                            if let index = filteredItems.firstIndex(where: { $0.id == item.id }) {
-                                deleteOffsets = IndexSet(integer: index)
-                                showingDeleteConfirm = true
+                        .swipeActions {
+                            Button(role: .destructive) {
+                                if let index = filteredItems.firstIndex(where: { $0.id == item.id }) {
+                                    deleteOffsets = IndexSet(integer: index)
+                                    showingDeleteConfirm = true
+                                }
+                            } label: {
+                                Label("削除", systemImage: "trash")
                             }
-                        } label: {
-                            Label("削除", systemImage: "trash")
                         }
                     }
                 }

--- a/refrigerator_management/Views/FoodRegisterView.swift
+++ b/refrigerator_management/Views/FoodRegisterView.swift
@@ -46,7 +46,7 @@ struct FoodRegisterView: View {
                             DatePicker("", selection: $expirationDate, displayedComponents: .date)
                                 .datePickerStyle(.graphical)
                                 .labelsHidden()
-                                .onChange(of: expirationDate) { _ in
+                                .onChange(of: expirationDate) { _, _ in
                                     showingDatePicker = false
                                 }
                             Button("閉じる") {


### PR DESCRIPTION
## Summary
- fix `FoodListView` row swipe actions so `item` is in scope
- update `onChange` usage in `FoodRegisterView` for iOS 17

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686bce9ca264832f94fe8446155c48ac