### PR TITLE
Add Google AdMob banner

### DIFF
--- a/AdMobInfo.plist
+++ b/AdMobInfo.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>GADApplicationIdentifier</key>
+    <string>ca-app-pub-3940256099942544~1458002511</string>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -7,3 +7,26 @@
 - 在庫一覧の閲覧・編集
 - 買い物リストの作成と在庫への反映
 - よく使うリストをテンプレートとして保存
+
+## 広告表示の設定
+
+このアプリでは Google AdMob を利用してバナー広告を表示しています。開発時はテスト用の AdUnitID（`ca-app-pub-3940256099942544/2934735716`）を使用してください。
+
+### 依存関係の追加
+
+Xcode の `Package Dependencies` に以下の URL を追加します。
+
+```
+https://github.com/googleads/swift-package-manager-google-mobile-ads.git
+```
+
+### Info.plist の設定例
+
+Info.plist に次のキーを追加してください。
+
+```
+<key>GADApplicationIdentifier</key>
+<string>ca-app-pub-3940256099942544~1458002511</string>
+```
+
+上記の ID はテスト用です。実運用ではご自身のアプリ ID に置き換えてください。

--- a/refrigerator_management/ContentView.swift
+++ b/refrigerator_management/ContentView.swift
@@ -12,7 +12,8 @@ struct ContentView: View {
     var body: some View {
         // TabView で在庫・買い物・テンプレートを切り替える
         NavigationStack {
-            TabView {
+            ZStack(alignment: .bottom) {
+                TabView {
                 // 在庫タブ
                 FoodListView(viewModel: foodViewModel)
                     .tabItem {
@@ -37,6 +38,10 @@ struct ContentView: View {
                 .tabItem {
                     Label("テンプレート", systemImage: "list.bullet.rectangle")
                 }
+                }
+                // 画面下部に常に表示するバナー広告
+                BannerAdView(adUnitID: "ca-app-pub-3940256099942544/2934735716")
+                    .frame(width: 320, height: 50)
             }
         }
     }

--- a/refrigerator_management/Views/BannerAdView.swift
+++ b/refrigerator_management/Views/BannerAdView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+import GoogleMobileAds
+
+/// Google AdMob バナー広告ビュー
+struct BannerAdView: UIViewRepresentable {
+    /// 表示する広告ユニットID
+    var adUnitID: String
+
+    func makeUIView(context: Context) -> GADBannerView {
+        let banner = GADBannerView(adSize: GADAdSizeBanner)
+        banner.adUnitID = adUnitID
+        banner.rootViewController = UIApplication.shared.connectedScenes
+            .compactMap { ($0 as? UIWindowScene)?.keyWindow?.rootViewController }
+            .first
+        banner.load(GADRequest())
+        return banner
+    }
+
+    func updateUIView(_ uiView: GADBannerView, context: Context) {
+        // 特に更新処理は不要
+    }
+}

--- a/refrigerator_management/refrigerator_managementApp.swift
+++ b/refrigerator_management/refrigerator_managementApp.swift
@@ -6,9 +6,23 @@
 //
 
 import SwiftUI
+import GoogleMobileAds
+
+/// Google Mobile Ads の初期化を行う AppDelegate
+class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+        // AdMob SDK の初期化
+        GADMobileAds.sharedInstance().start(completionHandler: nil)
+        return true
+    }
+}
 
 @main
 struct refrigerator_managementApp: App {
+    /// UIApplicationDelegateAdaptor で AppDelegate を使用
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
     var body: some Scene {
         WindowGroup {
             // アプリのメイン画面を表示


### PR DESCRIPTION
## Summary
- integrate GoogleMobileAds via `BannerAdView` using `UIViewRepresentable`
- initialize GoogleMobileAds in `AppDelegate`
- show banner at the bottom of `ContentView`
- document AdMob setup in README
- provide example Info.plist with required key

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686bdc310d64832fa5ded355633a2a57