### PR TITLE
Add AdMob application ID to generated Info.plist

### DIFF
--- a/refrigerator_management.xcodeproj/project.pbxproj
+++ b/refrigerator_management.xcodeproj/project.pbxproj
@@ -437,7 +437,8 @@
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+                               SWIFT_VERSION = 5.0;
+                               INFOPLIST_KEY_GADApplicationIdentifier = ca-app-pub-3940256099942544~1458002511;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
 				XROS_DEPLOYMENT_TARGET = 2.4;
 			};
@@ -476,8 +477,9 @@
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,7";
+                               SWIFT_VERSION = 5.0;
+                               INFOPLIST_KEY_GADApplicationIdentifier = ca-app-pub-3940256099942544~1458002511;
+                               TARGETED_DEVICE_FAMILY = "1,2,7";
 				XROS_DEPLOYMENT_TARGET = 2.4;
 			};
 			name = Release;


### PR DESCRIPTION
## Summary
- configure Xcode project to include `GADApplicationIdentifier`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686fb32e02dc832fb58b69eff3933cc3