### PR TITLE
Fix Info.plist settings for AdMob

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<!--
-   Info.plist
-   refrigerator_management
-
-   Created by 小林　景大 on 2025/07/08.
-   Copyright (c) 2025 ___ORGANIZATIONNAME___. All rights reserved.
--->
 <plist version="1.0">
-<dict/>
+<dict>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$(MARKETING_VERSION)</string>
+    <key>CFBundleVersion</key>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
+    <key>GADApplicationIdentifier</key>
+    <string>ca-app-pub-3940256099942544~1458002511</string>
+</dict>
 </plist>

--- a/refrigerator_management.xcodeproj/project.pbxproj
+++ b/refrigerator_management.xcodeproj/project.pbxproj
@@ -415,7 +415,8 @@
 				DEVELOPMENT_TEAM = G9BUXBTRYK;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
+                               GENERATE_INFOPLIST_FILE = NO;
+                               INFOPLIST_FILE = "Info.plist";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -438,7 +439,6 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
 				SWIFT_EMIT_LOC_STRINGS = YES;
                                SWIFT_VERSION = 5.0;
-                               INFOPLIST_KEY_GADApplicationIdentifier = ca-app-pub-3940256099942544~1458002511;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
 				XROS_DEPLOYMENT_TARGET = 2.4;
 			};
@@ -455,7 +455,8 @@
 				DEVELOPMENT_TEAM = G9BUXBTRYK;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
+                               GENERATE_INFOPLIST_FILE = NO;
+                               INFOPLIST_FILE = "Info.plist";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -478,7 +479,6 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
 				SWIFT_EMIT_LOC_STRINGS = YES;
                                SWIFT_VERSION = 5.0;
-                               INFOPLIST_KEY_GADApplicationIdentifier = ca-app-pub-3940256099942544~1458002511;
                                TARGETED_DEVICE_FAMILY = "1,2,7";
 				XROS_DEPLOYMENT_TARGET = 2.4;
 			};


### PR DESCRIPTION
## Summary
- provide a concrete `Info.plist` containing `GADApplicationIdentifier`
- switch build settings to use the manual Info.plist instead of generating one

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_686fb7ddc98c832f8c8d10abd3b4c7c0