### PR TITLE
Ensure GADApplicationIdentifier in final Info.plist

### DIFF
--- a/refrigerator_management.xcodeproj/project.pbxproj
+++ b/refrigerator_management.xcodeproj/project.pbxproj
@@ -415,8 +415,8 @@
 				DEVELOPMENT_TEAM = G9BUXBTRYK;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
-                               GENERATE_INFOPLIST_FILE = NO;
-                               INFOPLIST_FILE = "Info.plist";
+                               GENERATE_INFOPLIST_FILE = YES;
+                               INFOPLIST_FILE = "Property List 2.plist";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -455,8 +455,8 @@
 				DEVELOPMENT_TEAM = G9BUXBTRYK;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
-                               GENERATE_INFOPLIST_FILE = NO;
-                               INFOPLIST_FILE = "Info.plist";
+                               GENERATE_INFOPLIST_FILE = YES;
+                               INFOPLIST_FILE = "Property List 2.plist";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;


### PR DESCRIPTION
## Summary
- configure `Property List 2.plist` as the base Info.plist
- let Xcode generate the final Info.plist using this file

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_686fc003536c832f80e0b52b9aff39bf