### PR TITLE
Fix bottom tab hidden by overlay banner

### DIFF
--- a/refrigerator_management/ContentView.swift
+++ b/refrigerator_management/ContentView.swift
@@ -12,8 +12,7 @@ struct ContentView: View {
     var body: some View {
         // TabView で在庫・買い物・テンプレートを切り替える
         NavigationStack {
-            ZStack(alignment: .bottom) {
-                TabView {
+            TabView {
                 // 在庫タブ
                 FoodListView(viewModel: foodViewModel)
                     .tabItem {
@@ -38,7 +37,8 @@ struct ContentView: View {
                 .tabItem {
                     Label("テンプレート", systemImage: "list.bullet.rectangle")
                 }
-                }
+            }
+            .safeAreaInset(edge: .bottom) {
                 // 画面下部に常に表示するバナー広告
                 BannerAdView(adUnitID: "ca-app-pub-3940256099942544/2934735716")
                     .frame(width: 320, height: 50)


### PR DESCRIPTION
## Summary
- avoid overlaying the tab bar with the banner ad

## Testing
- `swift test -q` *(fails: `Could not find Package.swift`)*
- `xcodebuild -version` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686fc92091c4832f974264c7754231e0