### PR TITLE
Fix overlapped buttons

### DIFF
--- a/refrigerator_management/Views/FoodListView.swift
+++ b/refrigerator_management/Views/FoodListView.swift
@@ -18,8 +18,7 @@ struct FoodListView: View {
 
     var body: some View {
         NavigationView {
-            ZStack {
-                VStack {
+            VStack {
                 Picker("保存場所", selection: $selectedStorage) {
                     ForEach(StorageType.allCases) { type in
                         Text(type.rawValue).tag(type)
@@ -68,32 +67,6 @@ struct FoodListView: View {
                 .environment(\.editMode, $editMode)
                 .listStyle(.insetGrouped)
             }
-
-            // 右下の追加ボタン
-            VStack {
-                Spacer()
-                HStack {
-                    Button(action: {
-                        withAnimation { editMode = editMode.isEditing ? .inactive : .active }
-                    }) {
-                        Image(systemName: editMode.isEditing ? "checkmark.circle.fill" : "pencil.circle.fill")
-                            .resizable()
-                            .frame(width: 60, height: 60)
-                            .foregroundColor(.orange)
-                            .padding()
-                    }
-                    Spacer()
-                    Button(action: {
-                        showingRegister = true
-                    }) {
-                        Image(systemName: "plus.circle.fill")
-                            .resizable()
-                            .frame(width: 60, height: 60)
-                            .foregroundColor(.blue)
-                            .padding()
-                    }
-                }
-            }
         }
         .sheet(isPresented: $showingRegister) {
             FoodRegisterView { newItem in
@@ -108,6 +81,12 @@ struct FoodListView: View {
             }
         }
         .toolbar {
+            ToolbarItemGroup(placement: .navigationBarTrailing) {
+                EditButton()
+                Button(action: { showingRegister = true }) {
+                    Image(systemName: "plus")
+                }
+            }
             ToolbarItem(placement: .navigationBarLeading) {
                 if editMode == .active {
                     Button("削除") {

--- a/refrigerator_management/Views/ShoppingListView.swift
+++ b/refrigerator_management/Views/ShoppingListView.swift
@@ -17,8 +17,7 @@ struct ShoppingListView: View {
 
     var body: some View {
         NavigationView {
-            ZStack {
-                VStack {
+            VStack {
                     List {
                         ForEach(shoppingViewModel.shoppingItems) { item in
                             HStack(alignment: .top) {
@@ -104,41 +103,11 @@ struct ShoppingListView: View {
                     .environment(\.editMode, $editMode)
                     .listStyle(.insetGrouped)
                 }
-
-                // 編集・在庫追加ボタン
-                VStack {
-                    Spacer()
-                    HStack {
-                        Button(action: {
-                            withAnimation {
-                                editMode = editMode.isEditing ? .inactive : .active
-                                selection.removeAll()
-                            }
-                        }) {
-                            Image(systemName: editMode.isEditing ? "checkmark.circle.fill" : "pencil.circle.fill")
-                                .resizable()
-                                .frame(width: 60, height: 60)
-                                .foregroundColor(.orange)
-                                .padding()
-                        }
-                        Spacer()
-                        Button(action: {
-                            showingCartConfirm = true
-                        }) {
-                            Image(systemName: "cart.fill.badge.plus")
-                                .resizable()
-                                .frame(width: 60, height: 60)
-                                .foregroundColor(.blue)
-                                .padding()
-                        }
-                        .disabled(editMode == .active)
-                        .opacity(editMode == .active ? 0.4 : 1.0)
-                    }
-                }
             }
             .navigationTitle("買い物リスト")
             .toolbar {
                 ToolbarItemGroup(placement: .navigationBarTrailing) {
+                    EditButton()
                     Button(action: { showingRegister = true }) {
                         Image(systemName: "plus")
                     }
@@ -155,6 +124,12 @@ struct ShoppingListView: View {
                             showingTemplateNameAlert = true
                         }
                     }
+                }
+                ToolbarItem(placement: .bottomBar) {
+                    Button(action: { showingCartConfirm = true }) {
+                        Label("在庫へ追加", systemImage: "cart.fill.badge.plus")
+                    }
+                    .disabled(editMode == .active)
                 }
             }
             .sheet(item: $editingItem) { item in


### PR DESCRIPTION
## Summary
- move floating buttons into `toolbar` for Food and Shopping lists
- add cart button to bottom toolbar on shopping list

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686fcf23af44832fac5bbbcdd861e54b