### PR TITLE
Add Google AdMob integration

### DIFF
--- a/refrigerator_management/AdLogic/AdManager.swift
+++ b/refrigerator_management/AdLogic/AdManager.swift
@@ -1,0 +1,45 @@
+import GoogleMobileAds
+import UIKit
+
+/// インタースティシャル広告の読み込みと表示を管理するシングルトンクラス
+final class AdManager: NSObject, GADFullScreenContentDelegate {
+    static let shared = AdManager()
+
+    /// 読み込んだインタースティシャル広告
+    private var interstitial: GADInterstitialAd?
+    /// 連続表示を防ぐフラグ
+    private var hasShown = false
+
+    /// テスト用インタースティシャル広告ユニットID
+    private let adUnitID = "ca-app-pub-3940256099942544/4411468910"
+
+    private override init() {
+        super.init()
+    }
+
+    /// 広告を読み込む
+    func loadInterstitial() {
+        let request = GADRequest()
+        GADInterstitialAd.load(withAdUnitID: adUnitID, request: request) { [weak self] ad, error in
+            if let error = error {
+                print("[AdManager] Failed to load interstitial: \(error.localizedDescription)")
+                return
+            }
+            self?.interstitial = ad
+            self?.interstitial?.fullScreenContentDelegate = self
+            self?.hasShown = false
+        }
+    }
+
+    /// 読み込まれた広告を表示する
+    func showInterstitial(from rootViewController: UIViewController) {
+        guard let ad = interstitial, !hasShown else { return }
+        ad.present(fromRootViewController: rootViewController)
+        hasShown = true
+    }
+
+    // MARK: - GADFullScreenContentDelegate
+    func adDidDismissFullScreenContent(_ ad: GADFullScreenPresentingAd) {
+        interstitial = nil
+    }
+}

--- a/refrigerator_management/ContentView.swift
+++ b/refrigerator_management/ContentView.swift
@@ -8,6 +8,8 @@ struct ContentView: View {
     @StateObject private var shoppingViewModel = ShoppingViewModel()
     /// テンプレートを管理する ViewModel
     @StateObject private var templateViewModel = TemplateViewModel()
+    /// ゲーム結果画面の表示状態
+    @State private var showingResult = false
 
     var body: some View {
         // TabView で在庫・買い物・テンプレートを切り替え、下部に広告を配置
@@ -39,9 +41,23 @@ struct ContentView: View {
                 }
             }
 
+            // サンプルとしてゲームオーバー画面を開くボタン
+            Button("ゲーム終了") {
+                showingResult = true
+            }
+            .padding(.vertical)
+
             // 画面下部に常に表示するバナー広告
-            BannerAdView(adUnitID: "ca-app-pub-3940256099942544/2934735716")
+            AdMobBannerView(adUnitID: "ca-app-pub-3940256099942544/2934735716")
                 .frame(width: 320, height: 50)
+        }
+        // ゲーム終了時に表示する画面
+        .sheet(isPresented: $showingResult) {
+            ResultView()
+        }
+        // アプリ起動時にインタースティシャル広告を事前読み込み
+        .onAppear {
+            AdManager.shared.loadInterstitial()
         }
     }
 }

--- a/refrigerator_management/Views/AdMobBannerView.swift
+++ b/refrigerator_management/Views/AdMobBannerView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+import GoogleMobileAds
+
+/// SwiftUI で使用する Google AdMob バナー広告ビュー
+struct AdMobBannerView: UIViewRepresentable {
+    /// 表示する広告ユニットID
+    let adUnitID: String
+
+    func makeUIView(context: Context) -> GADBannerView {
+        let banner = GADBannerView(adSize: .banner)
+        banner.adUnitID = adUnitID
+        banner.rootViewController = UIApplication.shared.connectedScenes
+            .compactMap { ($0 as? UIWindowScene)?.keyWindow?.rootViewController }
+            .first
+        banner.load(GADRequest())
+        return banner
+    }
+
+    func updateUIView(_ uiView: GADBannerView, context: Context) {}
+}

--- a/refrigerator_management/Views/ResultView.swift
+++ b/refrigerator_management/Views/ResultView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+import GoogleMobileAds
+
+/// ゲーム終了後の結果表示とインタースティシャル広告表示例
+struct ResultView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("Game Over")
+                .font(.largeTitle)
+            Button("閉じる") {
+                if let root = UIApplication.shared.connectedScenes
+                    .compactMap({ ($0 as? UIWindowScene)?.keyWindow?.rootViewController })
+                    .first {
+                    AdManager.shared.showInterstitial(from: root)
+                }
+                dismiss()
+            }
+            .padding()
+        }
+        .onAppear {
+            AdManager.shared.loadInterstitial()
+        }
+    }
+}
+
+#if DEBUG
+struct ResultView_Previews: PreviewProvider {
+    static var previews: some View {
+        ResultView()
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add `AdManager` to load and display interstitial ads
- create `AdMobBannerView` for SwiftUI banner support
- show example result screen that displays an interstitial
- update `ContentView` with banner and interstitial demo

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686fd3fc50d4832f97114fc132275111