### PR TITLE
Fix shopping list bottom overlap

### DIFF
--- a/refrigerator_management/Views/ShoppingListView.swift
+++ b/refrigerator_management/Views/ShoppingListView.swift
@@ -15,6 +15,9 @@ struct ShoppingListView: View {
     @State private var deleteOffsets: IndexSet? = nil
     @State private var showingCartConfirm = false
 
+    /// 端末のセーフエリアを取得
+    @Environment(\.safeAreaInsets) private var safeAreaInsets
+
     var body: some View {
         NavigationView {
             VStack {
@@ -102,6 +105,8 @@ struct ShoppingListView: View {
                     }
                     .environment(\.editMode, $editMode)
                     .listStyle(.insetGrouped)
+                    // ボトムバーと重ならないように下部へ余白を追加
+                    .padding(.bottom, safeAreaInsets.bottom + 44)
                 }
             }
             .navigationTitle("買い物リスト")


### PR DESCRIPTION
## Summary
- adjust `ShoppingListView` layout to avoid overlap with bottom toolbar

## Testing
- `xcodebuild test -scheme refrigerator_management -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871b8c083d4832f983ca695f70eeeca