### PR TITLE
Fix AdMobBannerView constant

### DIFF
--- a/refrigerator_management/Views/AdMobBannerView.swift
+++ b/refrigerator_management/Views/AdMobBannerView.swift
@@ -7,7 +7,7 @@ struct AdMobBannerView: UIViewRepresentable {
     let adUnitID: String
 
     func makeUIView(context: Context) -> GADBannerView {
-        let banner = GADBannerView(adSize: .banner)
+        let banner = GADBannerView(adSize: GADAdSizeBanner)
         banner.adUnitID = adUnitID
         banner.rootViewController = UIApplication.shared.connectedScenes
             .compactMap { ($0 as? UIWindowScene)?.keyWindow?.rootViewController }


### PR DESCRIPTION
## Summary
- use `GADAdSizeBanner` constant when creating the banner view

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871c14a1604832fabca01abf2a62aac