### PR TITLE
Enhance list controls and UI cleanup

### DIFF
--- a/refrigerator_management/Views/FoodListView.swift
+++ b/refrigerator_management/Views/FoodListView.swift
@@ -66,6 +66,9 @@ struct FoodListView: View {
                 }
                 .environment(\.editMode, $editMode)
                 .listStyle(.insetGrouped)
+                .safeAreaInset(edge: .bottom) {
+                    Spacer().frame(height: 94)
+                }
             }
         }
         .sheet(isPresented: $showingRegister) {
@@ -87,11 +90,13 @@ struct FoodListView: View {
                     Image(systemName: "plus")
                 }
             }
-            ToolbarItem(placement: .navigationBarLeading) {
+            ToolbarItemGroup(placement: .bottomBar) {
                 if editMode == .active {
-                    Button("削除") {
+                    Button(role: .destructive) {
                         deleteOffsets = nil
                         showingDeleteConfirm = true
+                    } label: {
+                        Label("削除", systemImage: "trash")
                     }
                     .disabled(selection.isEmpty)
                 }

--- a/refrigerator_management/Views/ShoppingListView.swift
+++ b/refrigerator_management/Views/ShoppingListView.swift
@@ -46,6 +46,7 @@ struct ShoppingListView: View {
                                                         (item.isChecked ? .green : .gray))
                                         .padding(.trailing, 8)
                                 }
+                                .buttonStyle(.borderless)
 
                                 VStack(alignment: .leading, spacing: 4) {
                                     Text(item.name)
@@ -121,19 +122,23 @@ struct ShoppingListView: View {
                     }
                 }
                 ToolbarItem(placement: .navigationBarLeading) {
-                    if editMode == .active {
-                        Button("削除") {
-                            deleteOffsets = nil
-                            showingDeleteConfirm = true
-                        }.disabled(selection.isEmpty)
-                    } else {
+                    if editMode == .inactive {
                         Button("テンプレート保存") {
                             newTemplateName = ""
                             showingTemplateNameAlert = true
                         }
                     }
                 }
-                ToolbarItem(placement: .bottomBar) {
+                ToolbarItemGroup(placement: .bottomBar) {
+                    if editMode == .active {
+                        Button(role: .destructive) {
+                            deleteOffsets = nil
+                            showingDeleteConfirm = true
+                        } label: {
+                            Label("削除", systemImage: "trash")
+                        }
+                        .disabled(selection.isEmpty)
+                    }
                     Button(action: { showingCartConfirm = true }) {
                         Label("在庫へ追加", systemImage: "cart.fill.badge.plus")
                     }

--- a/refrigerator_management/Views/TemplateListView.swift
+++ b/refrigerator_management/Views/TemplateListView.swift
@@ -53,9 +53,12 @@ struct TemplateListView: View {
                 }
             }
             .listStyle(.insetGrouped)
+            .safeAreaInset(edge: .bottom) {
+                Spacer().frame(height: 94)
+            }
             .navigationTitle("買い物テンプレート")
             .toolbar {
-                ToolbarItemGroup(placement: .navigationBarTrailing) {
+                ToolbarItemGroup(placement: .bottomBar) {
                     EditButton()
                     Button(action: {
                         let new = Template(name: "新規テンプレート", items: [])


### PR DESCRIPTION
## Summary
- enable bottom-bar delete for food list
- support bottom-bar delete in shopping list and fix check button style
- move template edit controls to bottom bar
- add safe area spacers to list views

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6871ceab2fa8832f946c00b43e57a115