### PR TITLE
Fix unmatched brace in ShoppingListView

### DIFF
--- a/refrigerator_management/Views/ShoppingListView.swift
+++ b/refrigerator_management/Views/ShoppingListView.swift
@@ -173,8 +173,6 @@ struct ShoppingListView: View {
       selection.removeAll()
     }
 
-  }
-
   private func processCheckedItems() {
     let checkedItems = shoppingViewModel.extractCheckedItemsAndRemove()
     let groupedItems = Dictionary(grouping: checkedItems, by: { $0.name })


### PR DESCRIPTION
## Summary
- fix unmatched closing brace which closed the `ShoppingListView` struct early

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6871d8e2e7d0832fb6c3491ec332bbc4