### PR TITLE
Add icons and animations

### DIFF
--- a/refrigerator_management/Helpers/DateUtils.swift
+++ b/refrigerator_management/Helpers/DateUtils.swift
@@ -12,7 +12,9 @@ struct DateUtils {
         let today = calendar.startOfDay(for: Date())
         if date < today {
             return .red
-        } else if calendar.isDateInTomorrow(date) {
+        } else if calendar.isDate(date, equalTo: today, toGranularity: .day) || calendar.isDateInTomorrow(date) {
+            return .orange
+        } else if isExpiringSoon(date) {
             return .orange
         } else {
             return .gray
@@ -30,5 +32,12 @@ struct DateUtils {
         } else {
             return "期限: \(dateFormatter.string(from: date))"
         }
+    }
+
+    /// 3日以内に期限が来るかを判定
+    static func isExpiringSoon(_ date: Date) -> Bool {
+        let calendar = Calendar.current
+        guard let limit = calendar.date(byAdding: .day, value: 3, to: Date()) else { return false }
+        return date <= limit
     }
 }

--- a/refrigerator_management/Models/FoodItem.swift
+++ b/refrigerator_management/Models/FoodItem.swift
@@ -1,6 +1,7 @@
 // Models/FoodItem.swift
 
 import Foundation
+import SwiftUI
 
 // 保存場所（冷蔵・冷凍・常温）
 enum StorageType: String, CaseIterable, Identifiable, Codable {
@@ -9,6 +10,24 @@ enum StorageType: String, CaseIterable, Identifiable, Codable {
     case pantry = "常温"
 
     var id: String { self.rawValue }
+
+    /// 表示用アイコン
+    var icon: String {
+        switch self {
+        case .fridge: return "🧊"
+        case .freezer: return "❄️"
+        case .pantry: return "🌤"
+        }
+    }
+
+    /// テーマカラー
+    var color: Color {
+        switch self {
+        case .fridge: return .blue
+        case .freezer: return .purple
+        case .pantry: return .orange
+        }
+    }
 }
 
 // 食材カテゴリ
@@ -16,9 +35,21 @@ enum FoodCategory: String, CaseIterable, Identifiable, Codable {
     case vegetable = "野菜"
     case meat = "肉"
     case dairy = "乳製品"
+    case drink = "飲料"
     case other = "その他"
 
     var id: String { self.rawValue }
+
+    /// カテゴリを表すアイコン
+    var icon: String {
+        switch self {
+        case .vegetable: return "🥬"
+        case .meat: return "🍖"
+        case .dairy: return "🥛"
+        case .drink: return "🧃"
+        case .other: return "📦"
+        }
+    }
 }
 
 // 食材モデル

--- a/refrigerator_management/Views/FoodListView.swift
+++ b/refrigerator_management/Views/FoodListView.swift
@@ -23,15 +23,24 @@ struct FoodListView: View {
 
         List {
           ForEach(filteredItems) { item in
-            HStack(alignment: .top) {
+            HStack(alignment: .top, spacing: 12) {
+              Text(item.storageType.icon)
+                .font(.title3)
+                .frame(width: 24)
               VStack(alignment: .leading, spacing: 4) {
-                Text(item.name)
-                  .font(.headline)
+                HStack {
+                  Text(item.name)
+                    .font(.headline)
+                  Text(item.category.icon)
+                }
                 HStack(spacing: 8) {
                   Text("x\(item.quantity)")
                   Text(item.category.rawValue)
                   Text(dateLabel(for: item.expirationDate))
                     .foregroundColor(color(for: item.expirationDate))
+                  if DateUtils.isExpiringSoon(item.expirationDate) {
+                    Text("⚠️")
+                  }
                 }
                 .font(.caption)
                 .foregroundColor(.gray)
@@ -40,6 +49,7 @@ struct FoodListView: View {
             }
             .padding(.vertical, 4)
             .contentShape(Rectangle())
+            .background(item.storageType.color.opacity(0.1))
             .cornerRadius(8)
             .onTapGesture {
               editingItem = item
@@ -47,7 +57,9 @@ struct FoodListView: View {
             .swipeActions {
               Button(role: .destructive) {
                 if let index = filteredItems.firstIndex(where: { $0.id == item.id }) {
-                  viewModel.foodItems.removeAll { $0.id == item.id }
+                  withAnimation {
+                    viewModel.foodItems.removeAll { $0.id == item.id }
+                  }
                 }
               } label: {
                 Label("削除", systemImage: "trash")
@@ -68,13 +80,17 @@ struct FoodListView: View {
     .navigationViewStyle(.stack)
     .sheet(isPresented: $showingRegister) {
       FoodRegisterView { newItem in
-        viewModel.add(item: newItem)
+        withAnimation {
+          viewModel.add(item: newItem)
+        }
       }
     }
     .sheet(item: $editingItem) { item in
       FoodRegisterView(itemToEdit: item) { updatedItem in
         if let index = viewModel.foodItems.firstIndex(where: { $0.id == updatedItem.id }) {
-          viewModel.foodItems[index] = updatedItem
+          withAnimation {
+            viewModel.foodItems[index] = updatedItem
+          }
         }
       }
     }

--- a/refrigerator_management/Views/ShoppingListView.swift
+++ b/refrigerator_management/Views/ShoppingListView.swift
@@ -18,22 +18,29 @@ struct ShoppingListView: View {
           shoppingViewModel.shoppingItems.sorted { $0.addedAt < $1.addedAt },
           id: \.id
         ) { item in
-          HStack(alignment: .top) {
+          HStack(alignment: .top, spacing: 12) {
             Button(action: {
-              shoppingViewModel.toggleCheck(for: item)
+              withAnimation {
+                shoppingViewModel.toggleCheck(for: item)
+              }
             }) {
               Image(systemName: item.isChecked ? "checkmark.circle.fill" : "circle")
                 .resizable()
                 .frame(width: 28, height: 28)
                 .foregroundColor(item.isChecked ? .green : .gray)
-                .padding(.trailing, 8)
             }
             .buttonStyle(.borderless)
 
+            Text(item.storageType.icon)
+              .font(.title3)
+
             VStack(alignment: .leading, spacing: 4) {
-              Text(item.name)
-                .font(.headline)
-                .strikethrough(item.isChecked)
+              HStack {
+                Text(item.name)
+                  .font(.headline)
+                  .strikethrough(item.isChecked)
+                Text(item.category.icon)
+              }
 
               HStack(spacing: 8) {
                 Text("x\(item.quantity)")
@@ -41,6 +48,9 @@ struct ShoppingListView: View {
                 if let date = item.expirationDate {
                   Text(dateLabel(for: date))
                     .foregroundColor(color(for: date))
+                  if DateUtils.isExpiringSoon(date) {
+                    Text("⚠️")
+                  }
                 } else if let period = item.expirationPeriod {
                   Text("期限: \(period)日")
                 }
@@ -89,12 +99,16 @@ struct ShoppingListView: View {
     .navigationViewStyle(.stack)
     .sheet(item: $editingItem) { item in
       ShoppingItemRegisterView(itemToEdit: item) { updatedItem in
-        shoppingViewModel.updateItem(updatedItem)
+        withAnimation {
+          shoppingViewModel.updateItem(updatedItem)
+        }
       }
     }
     .sheet(isPresented: $showingRegister) {
       ShoppingItemRegisterView { newItem in
-        shoppingViewModel.add(newItem)
+        withAnimation {
+          shoppingViewModel.add(newItem)
+        }
       }
     }
     .alert("テンプレート名を入力", isPresented: $showingTemplateNameAlert) {

--- a/refrigerator_management/Views/TemplateListView.swift
+++ b/refrigerator_management/Views/TemplateListView.swift
@@ -21,9 +21,13 @@ struct TemplateListView: View {
                                 .bold()
                                 .underline()
                             ForEach(template.items) { item in
-                                Text("\(item.name) × \(item.quantity)")
-                                    .font(.caption)
-                                    .foregroundColor(.gray)
+                                HStack(spacing: 4) {
+                                    Text(item.storageType.icon)
+                                    Text(item.category.icon)
+                                    Text("\(item.name) × \(item.quantity)")
+                                }
+                                .font(.caption)
+                                .foregroundColor(.gray)
                             }
                         }
                         Spacer()
@@ -99,7 +103,9 @@ struct TemplateListView: View {
             Spacer()
             Button(action: {
                 let new = Template(name: "新規テンプレート", items: [])
-                templateViewModel.templates.append(new)
+                withAnimation {
+                    templateViewModel.templates.append(new)
+                }
                 editingIndex = templateViewModel.templates.count - 1
                 showingEditSheet = true
             }) {

--- a/refrigerator_management/refrigerator_managementApp.swift
+++ b/refrigerator_management/refrigerator_managementApp.swift
@@ -29,6 +29,7 @@ struct refrigerator_managementApp: App {
             ContentView()
                 // アプリ全体のロケールを日本語に設定
                 .environment(\.locale, Locale(identifier: "ja_JP"))
+                .tint(.mint)
         }
     }
 }


### PR DESCRIPTION
## Summary
- add icon and color helpers to `StorageType` and `FoodCategory`
- highlight near-expiration dates
- show storage and category icons in list views
- animate add/edit actions
- use mint tint color for the app

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877b5cc0190832fb580cf0bc2c08f37