### PR TITLE
Fix TemplateEditView toolbar

### DIFF
--- a/refrigerator_management/Views/TemplateEditView.swift
+++ b/refrigerator_management/Views/TemplateEditView.swift
@@ -59,11 +59,13 @@ struct TemplateEditView: View {
             }
         }
         .navigationTitle("テンプレート編集")
-        .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button("完了") { presentationMode.wrappedValue.dismiss() }
+        .toolbar(content: {
+            ToolbarItemGroup(placement: .navigationBarTrailing) {
+                Button("完了") {
+                    presentationMode.wrappedValue.dismiss()
+                }
             }
-        }
+        })
     }
 }
 


### PR DESCRIPTION
## Summary
- resolve `toolbar(content:)` ambiguity by explicitly specifying overload
- show "完了" button using `ToolbarItemGroup` and dismiss the view when tapped

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880f824b3d4832fab73c01fd510143b