### PR TITLE
Add Design Tokens (Neon Cyber Theme)

### DIFF
--- a/refrigerator_management/ContentView.swift
+++ b/refrigerator_management/ContentView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+
 /// アプリのメイン画面を構成する View
 struct ContentView: View {
     /// 在庫を管理する ViewModel
@@ -38,7 +39,7 @@ struct ContentView: View {
                     Label("テンプレート", systemImage: "list.bullet.rectangle")
                 }
             }
-            .padding(.bottom, 50)
+            .padding(.bottom, DesignTokens.Spacing.xl * 2)
 
 
 
@@ -46,6 +47,8 @@ struct ContentView: View {
             AdMobBannerView(adUnitID: "ca-app-pub-4060136684986886/3240209100")
                 .frame(width: 320, height: 50)
         }
+        .font(DesignTokens.Typography.body)
+        .background(DesignTokens.Colors.backgroundDark)
         // アプリ起動時にインタースティシャル広告を事前読み込み
         .onAppear {
             AdManager.shared.loadInterstitial()

--- a/refrigerator_management/Design/DesignTokens.swift
+++ b/refrigerator_management/Design/DesignTokens.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+enum DesignTokens {
+    enum Colors {
+        static let backgroundDark = Color(hex: "#0A0A0F")
+        static let surface = Color(hex: "#101018")
+        static let neonBlue = Color(hex: "#00E5FF")
+        static let neonBlueDeep = Color(hex: "#007ACC")
+        static let neonPurple = Color(hex: "#A020F0")
+        static let neonGreen = Color(hex: "#39FF14")   // 正解
+        static let neonRed = Color(hex: "#FF073A")     // 不正解
+        static let onDark = Color.white.opacity(0.92)
+        static let onMuted = Color.white.opacity(0.7)
+    }
+
+    enum Typography {
+        static let digitalMono = Font.system(.largeTitle, design: .monospaced)
+        static let title = Font.system(size: 28, weight: .bold)
+        static let body = Font.system(size: 17, weight: .regular)
+    }
+
+    enum Spacing {
+        static let s: CGFloat = 8
+        static let m: CGFloat = 12
+        static let l: CGFloat = 16
+        static let xl: CGFloat = 24
+    }
+
+    enum Radius {
+        static let m: CGFloat = 12
+        static let l: CGFloat = 16
+    }
+
+    enum Elevation {
+        struct Keycap: ViewModifier {
+            func body(content: Content) -> some View {
+                content.shadow(color: Colors.neonBlue.opacity(0.25), radius: 8, y: 2)
+            }
+        }
+    }
+}
+
+extension View {
+    func keycapShadow() -> some View {
+        modifier(DesignTokens.Elevation.Keycap())
+    }
+
+    func glow(_ color: Color, radius: CGFloat = 12) -> some View {
+        shadow(color: color, radius: radius)
+    }
+}
+
+extension Color {
+    init(hex: String) {
+        var hexString = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hexString).scanHexInt64(&int)
+        let r, g, b: UInt64
+        switch hexString.count {
+        case 6: // RGB (24-bit)
+            (r, g, b) = (int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+        default:
+            (r, g, b) = (1, 1, 0)
+        }
+        self.init(.sRGB,
+                  red: Double(r) / 255,
+                  green: Double(g) / 255,
+                  blue: Double(b) / 255,
+                  opacity: 1)
+    }
+}

--- a/refrigerator_management/Views/BatchDeleteBar.swift
+++ b/refrigerator_management/Views/BatchDeleteBar.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+
 struct BatchDeleteBar: View {
     var selectionIsEmpty: Bool
     var deleteAction: () -> Void
@@ -12,9 +13,10 @@ struct BatchDeleteBar: View {
             .disabled(selectionIsEmpty)
             Spacer()
         }
-        .padding()
+        .font(DesignTokens.Typography.body)
+        .padding(DesignTokens.Spacing.l)
         .frame(maxWidth: .infinity)
-        .background(.bar)
+        .background(DesignTokens.Colors.surface)
     }
 }
 

--- a/refrigerator_management/Views/FoodListView.swift
+++ b/refrigerator_management/Views/FoodListView.swift
@@ -1,4 +1,6 @@
 import SwiftUI
+// Design Tokens
+
 
 struct FoodListView: View {
   @State private var selectedStorage: StorageType = .fridge
@@ -19,21 +21,21 @@ struct FoodListView: View {
           }
         }
         .pickerStyle(.segmented)
-        .padding(.horizontal)
+        .padding(.horizontal, DesignTokens.Spacing.l)
 
         List {
           ForEach(filteredItems) { item in
-            HStack(alignment: .top, spacing: 12) {
+            HStack(alignment: .top, spacing: DesignTokens.Spacing.m) {
               Text(item.storageType.icon)
-                .font(.title3)
+                .font(DesignTokens.Typography.title)
                 .frame(width: 24)
-              VStack(alignment: .leading, spacing: 4) {
+              VStack(alignment: .leading, spacing: DesignTokens.Spacing.s / 2) {
                 HStack {
                   Text(item.name)
-                    .font(.headline)
+                    .font(DesignTokens.Typography.body).bold()
                   Text(item.category.icon)
                 }
-                HStack(spacing: 8) {
+                HStack(spacing: DesignTokens.Spacing.s) {
                   Text("x\(item.quantity)")
                   Text(item.category.rawValue)
                   Text(dateLabel(for: item.expirationDate))
@@ -42,15 +44,15 @@ struct FoodListView: View {
                     Text("⚠️")
                   }
                 }
-                .font(.caption)
-                .foregroundColor(.gray)
+                .font(DesignTokens.Typography.body)
+                .foregroundColor(DesignTokens.Colors.onMuted)
               }
               Spacer()
             }
-            .padding(.vertical, 4)
+            .padding(.vertical, DesignTokens.Spacing.s / 2)
             .contentShape(Rectangle())
             .background(item.storageType.color.opacity(0.1))
-            .cornerRadius(8)
+            .cornerRadius(DesignTokens.Radius.m)
             .onTapGesture {
               editingItem = item
             }
@@ -68,6 +70,8 @@ struct FoodListView: View {
           }
         }
         .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
+        .background(DesignTokens.Colors.backgroundDark)
         .safeAreaInset(edge: .bottom) {
           Spacer().frame(height: 94)
         }
@@ -77,6 +81,7 @@ struct FoodListView: View {
         bottomBar
       }
     }
+    .background(DesignTokens.Colors.backgroundDark)
     .navigationViewStyle(.stack)
     .sheet(isPresented: $showingRegister) {
       FoodRegisterView { newItem in
@@ -116,7 +121,8 @@ struct FoodListView: View {
       }
       Spacer()
     }
-    .padding()
-    .background(.bar)
+    .font(DesignTokens.Typography.body)
+    .padding(DesignTokens.Spacing.l)
+    .background(DesignTokens.Colors.surface)
   }
 }

--- a/refrigerator_management/Views/FoodRegisterView.swift
+++ b/refrigerator_management/Views/FoodRegisterView.swift
@@ -2,6 +2,7 @@
 
 import SwiftUI
 
+
 struct FoodRegisterView: View {
     @Environment(\.presentationMode) var presentationMode
     @State private var name: String = ""
@@ -52,7 +53,7 @@ struct FoodRegisterView: View {
                             Button("閉じる") {
                                 showingDatePicker = false
                             }
-                            .padding()
+                            .padding(DesignTokens.Spacing.m)
                         }
                     }
                 }
@@ -97,6 +98,7 @@ struct FoodRegisterView: View {
                     .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
                 }
             }
+            .font(DesignTokens.Typography.body)
             .navigationTitle(itemToEdit == nil ? "食材を追加" : "食材を編集")
             .onAppear {
                 // 編集時のみ初期値をセット
@@ -109,5 +111,6 @@ struct FoodRegisterView: View {
                 }
             }
         }
+        .background(DesignTokens.Colors.backgroundDark)
     }
 }

--- a/refrigerator_management/Views/ShoppingItemRegisterView.swift
+++ b/refrigerator_management/Views/ShoppingItemRegisterView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+
 struct ShoppingItemRegisterView: View {
     @Environment(\.presentationMode) var presentationMode
     @State private var name: String = ""
@@ -75,6 +76,7 @@ struct ShoppingItemRegisterView: View {
                     .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
                 }
             }
+            .font(DesignTokens.Typography.body)
             .navigationTitle(itemToEdit == nil ? "食材を追加" : "食材を編集")
             .onAppear {
                 if let item = itemToEdit {
@@ -86,5 +88,6 @@ struct ShoppingItemRegisterView: View {
                 }
             }
         }
+        .background(DesignTokens.Colors.backgroundDark)
     }
 }

--- a/refrigerator_management/Views/ShoppingListView.swift
+++ b/refrigerator_management/Views/ShoppingListView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+
 struct ShoppingListView: View {
   @ObservedObject var shoppingViewModel: ShoppingViewModel
   @ObservedObject var foodViewModel: FoodViewModel
@@ -18,7 +19,7 @@ struct ShoppingListView: View {
           shoppingViewModel.shoppingItems.sorted { $0.addedAt < $1.addedAt },
           id: \.id
         ) { item in
-          HStack(alignment: .top, spacing: 12) {
+          HStack(alignment: .top, spacing: DesignTokens.Spacing.m) {
             Button(action: {
               withAnimation {
                 shoppingViewModel.toggleCheck(for: item)
@@ -27,22 +28,22 @@ struct ShoppingListView: View {
               Image(systemName: item.isChecked ? "checkmark.circle.fill" : "circle")
                 .resizable()
                 .frame(width: 28, height: 28)
-                .foregroundColor(item.isChecked ? .green : .gray)
+                .foregroundColor(item.isChecked ? DesignTokens.Colors.neonGreen : DesignTokens.Colors.onMuted)
             }
             .buttonStyle(.borderless)
 
             Text(item.storageType.icon)
-              .font(.title3)
+              .font(DesignTokens.Typography.title)
 
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.s / 2) {
               HStack {
                 Text(item.name)
-                  .font(.headline)
+                  .font(DesignTokens.Typography.body).bold()
                   .strikethrough(item.isChecked)
                 Text(item.category.icon)
               }
 
-              HStack(spacing: 8) {
+              HStack(spacing: DesignTokens.Spacing.s) {
                 Text("x\(item.quantity)")
                 Text(item.category.rawValue)
                 if let date = item.expirationDate {
@@ -55,13 +56,13 @@ struct ShoppingListView: View {
                   Text("期限: \(period)日")
                 }
               }
-              .font(.caption)
-              .foregroundColor(.gray)
+              .font(DesignTokens.Typography.body)
+              .foregroundColor(DesignTokens.Colors.onMuted)
 
               if let note = item.note, !note.isEmpty {
                 Text(note)
-                  .font(.caption)
-                  .foregroundColor(.gray)
+                  .font(DesignTokens.Typography.body)
+                  .foregroundColor(DesignTokens.Colors.onMuted)
               }
             }
             .onTapGesture {
@@ -70,9 +71,9 @@ struct ShoppingListView: View {
             Spacer()
           }
           .contentShape(Rectangle())
-          .padding(.vertical, 8)
-          .background(item.isChecked ? Color.green.opacity(0.15) : Color.clear)
-          .cornerRadius(8)
+          .padding(.vertical, DesignTokens.Spacing.s)
+          .background(item.isChecked ? DesignTokens.Colors.neonGreen.opacity(0.15) : Color.clear)
+          .cornerRadius(DesignTokens.Radius.m)
           .swipeActions {
             Button(role: .destructive) {
               if let index = shoppingViewModel.shoppingItems.firstIndex(where: {
@@ -88,6 +89,8 @@ struct ShoppingListView: View {
         }
       }
       .listStyle(.insetGrouped)
+      .scrollContentBackground(.hidden)
+      .background(DesignTokens.Colors.backgroundDark)
       .safeAreaInset(edge: .bottom) {
         Spacer().frame(height: 94)
       }
@@ -96,6 +99,7 @@ struct ShoppingListView: View {
         bottomBar
       }
     }
+    .background(DesignTokens.Colors.backgroundDark)
     .navigationViewStyle(.stack)
     .sheet(item: $editingItem) { item in
       ShoppingItemRegisterView(itemToEdit: item) { updatedItem in
@@ -183,7 +187,7 @@ struct ShoppingListView: View {
   }
 
   private var bottomBar: some View {
-    HStack(spacing: 24) {
+    HStack(spacing: DesignTokens.Spacing.xl) {
       Button(action: {
         showingRegister = true
       }) {
@@ -203,8 +207,9 @@ struct ShoppingListView: View {
         Label("在庫へ追加", systemImage: "cart.fill.badge.plus")
       }
     }
-    .padding()
+    .font(DesignTokens.Typography.body)
+    .padding(DesignTokens.Spacing.l)
     .frame(maxWidth: .infinity)
-    .background(.bar)
+    .background(DesignTokens.Colors.surface)
   }
 }

--- a/refrigerator_management/Views/TemplateEditView.swift
+++ b/refrigerator_management/Views/TemplateEditView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+
 struct TemplateEditView: View {
     @Binding var template: Template
     @Environment(\.presentationMode) var presentationMode
@@ -12,7 +13,7 @@ struct TemplateEditView: View {
 
             Section(header: Text("食材一覧")) {
                 ForEach($template.items) { $item in
-                    VStack(alignment: .leading, spacing: 4) {
+                    VStack(alignment: .leading, spacing: DesignTokens.Spacing.s / 2) {
                         TextField("食材名", text: $item.name)
 
                         Stepper(value: $item.quantity, in: 1...99) {
@@ -38,7 +39,7 @@ struct TemplateEditView: View {
                             }
                         }
                     }
-                    .padding(.vertical, 4)
+                    .padding(.vertical, DesignTokens.Spacing.s / 2)
                 }
                 .onDelete { indices in
                     withAnimation {
@@ -58,6 +59,8 @@ struct TemplateEditView: View {
                 }
             }
         }
+        .font(DesignTokens.Typography.body)
+        .background(DesignTokens.Colors.backgroundDark)
         .navigationTitle("テンプレート編集")
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {

--- a/refrigerator_management/Views/TemplateListView.swift
+++ b/refrigerator_management/Views/TemplateListView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+
 struct TemplateListView: View {
     @ObservedObject var templateViewModel: TemplateViewModel
     @ObservedObject var shoppingViewModel: ShoppingViewModel
@@ -16,19 +17,18 @@ struct TemplateListView: View {
                 ForEach(templateViewModel.templates.indices, id: \.self) { index in
                     let template = templateViewModel.templates[index]
                     HStack(alignment: .top) {
-                        VStack(alignment: .leading, spacing: 4) {
+                        VStack(alignment: .leading, spacing: DesignTokens.Spacing.s / 2) {
                             Text(template.name)
-                                .font(.title3)
-                                .bold()
+                                .font(DesignTokens.Typography.title)
                                 .underline()
                             ForEach(template.items) { item in
-                                HStack(spacing: 4) {
+                                HStack(spacing: DesignTokens.Spacing.s / 2) {
                                     Text(item.storageType.icon)
                                     Text(item.category.icon)
                                     Text("\(item.name) × \(item.quantity)")
                                 }
-                                .font(.caption)
-                                .foregroundColor(.gray)
+                                .font(DesignTokens.Typography.body)
+                                .foregroundColor(DesignTokens.Colors.onMuted)
                             }
                         }
                         Spacer()
@@ -39,7 +39,7 @@ struct TemplateListView: View {
                         }
                         .buttonStyle(BorderlessButtonStyle())
                     }
-                    .padding(.vertical, 4)
+                    .padding(.vertical, DesignTokens.Spacing.s / 2)
                     .contentShape(Rectangle())
                     .onTapGesture {
                         templateToApply = template
@@ -56,6 +56,8 @@ struct TemplateListView: View {
                 }
             }
             .listStyle(.insetGrouped)
+            .scrollContentBackground(.hidden)
+            .background(DesignTokens.Colors.backgroundDark)
             .safeAreaInset(edge: .bottom) {
                 Spacer().frame(height: 94)
             }
@@ -64,6 +66,7 @@ struct TemplateListView: View {
                 bottomBar
             }
         }
+        .background(DesignTokens.Colors.backgroundDark)
         .navigationViewStyle(.stack)
         .alert("このテンプレートを買い物リストに反映しますか？", isPresented: $showingConfirm, presenting: templateToApply) { template in
             Button("キャンセル", role: .cancel) {}
@@ -129,8 +132,9 @@ struct TemplateListView: View {
             }
             Spacer()
         }
-        .padding()
-        .background(.bar)
+        .font(DesignTokens.Typography.body)
+        .padding(DesignTokens.Spacing.l)
+        .background(DesignTokens.Colors.surface)
     }
 }
 

--- a/refrigerator_management/refrigerator_managementApp.swift
+++ b/refrigerator_management/refrigerator_managementApp.swift
@@ -50,7 +50,7 @@ struct refrigerator_managementApp: App {
             ContentView()
                 // アプリ全体のロケールを日本語に設定
                 .environment(\.locale, Locale(identifier: "ja_JP"))
-                .tint(.mint)
+                .tint(DesignTokens.Colors.neonBlue)
         }
     }
 }


### PR DESCRIPTION
## Summary
- add DesignTokens.swift centralizing neon cyber colors, fonts, spacing, radii, and utilities
- refactor SwiftUI views to consume tokens for consistent styling
- set global tint to neon blue

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896171c0b68832f912ac9318a365682